### PR TITLE
Fix response codes for response tuples and json responses

### DIFF
--- a/eggs/schematra/schematra.scm
+++ b/eggs/schematra/schematra.scm
@@ -1062,7 +1062,7 @@
                                                (sendfile f (response-port (current-response)))
                                                (finish-response-body (current-response))))
                                            [(exn i/o file) (send-status 'forbidden)])
-                                         (send-response body: (current-body)))
+                                         (send-response status: orig-status body: (current-body)))
                                      (cond
                                        [(string? response-tuple) `(ok ,response-tuple ())]
                                        [(is-chiccup-response? response-tuple) `(ok ,response-tuple ())]


### PR DESCRIPTION
This addresses the issue outlined in issue #6 in the GitHub Issues section.

The established tests passed after the simple change was made, but this is not comforting, as the tests all passed before the change was made as well (presently unclear to me why). Will consult with maintainer before introducing regression tests, as I'm not yet familiar with how the testing system works, and would want guidance on style before updating the corresponding test (should a new numbered section for response codes be written, or should new tests pertaining to codes go under the response types section?).

In the meantime, Chicken interpreter REPL usage of Schematra confirms the changes have rectified the issue.