### PR TITLE
Implement named parameter for banner suppression

### DIFF
--- a/eggs/schematra/schematra.scm
+++ b/eggs/schematra/schematra.scm
@@ -1144,9 +1144,10 @@
 ;; This function starts the Spiffy web server with Schematra routing enabled.
 ;;
 ;; ### Parameters
-;;   - `port`: integer - HTTP server port (default: 8080)  
+;;   - `port`: integer - HTTP server port (default: 8080)
 ;;   - `repl?`: boolean - Enabled NREPL, only if dev mode is true (default: #f)
 ;;   - `repl-port`: integer - REPL port for development mode (default: 1234)
+;;   - `show-banner?`: boolean - Displays Schematra startup banner (default: #t)
 ;;
 ;; ### Foreground vs background
 ;; By default, `schematra-start` blocks the current thread. The one
@@ -1173,6 +1174,7 @@
                          (port 8080)
                          (bind-address #f)
                          (background (running-interactively?))
+                         (show-banner? #t)
                          (log-output (current-output-port))
                          (log-level 'info)
                          (log-format 'text))
@@ -1211,9 +1213,9 @@
   (server-software `(("Schematra"
                       ,(conc version-major "." version-minor)
                       ,(conc "Running on CHICKEN " (chicken-version)))))
-  (display (schematra-banner))
   (server-port port)
   (server-bind-address bind-address)
+  (when show-banner? (display (schematra-banner)))
 
   (if background
       (thread-start! (lambda () (start-server)))


### PR DESCRIPTION
A simple boolean that defaults to true (banner shown) was implemented. This addresses the feature request in issue #5.

The incorrectly displayed port issue mentioned in issue #4 was also fixed by simply moving the invocation of schematra-banner function below the server-port function. It makes sense to rectify the issue in the same commit since the newly implemented conditional applies to the exact code in question.

The banner is now optional and the correct port (if changed from default) now displays if the banner is shown.

All existing tests still pass after the changes are applied. No new tests were introduced, as they would involve observing output to stdout and may be quite noisy to implement among the tests pertaining to coverage of core functionality, though I am willing to write tests regarding these changes if maintainer deems it to make sense.

The new named parameter was placed above the log parameters to avoid diff noise with the closing parenthesis.

Trailing whitespace was removed from one comment line.